### PR TITLE
Project overhaul

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ authors = ["Allan J. <contato.allanj@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-rlua = "0.15.3"
+hlua = "0.4.1"
+rusqlite = "0.16.0"

--- a/foo.lua
+++ b/foo.lua
@@ -1,14 +1,7 @@
-print('Player starting HP: ' .. player:hp())
-print('Player starting Zeny: ' .. player:zeny())
+print('Player starting HP: ' .. hp())
 
-print('Now lets add some zenies')
+print('Now lets add some hp')
 
-player:add_zeny(1)
+add_hp(1090)
 
-print('Player current Zeny: ' .. player:zeny())
-
-print('Now lets add some zenies')
-
-player:add_zeny(10)
-
-print('Player current Zeny: ' .. player:zeny())
+print('Player current HP: ' .. hp())


### PR DESCRIPTION
With this PR we start to make use of the `hlua` instead of `rlua` lib, as we don't **YET** need all the safety rlua brings to the table.
Also, we're using `sqlite` as db and `rusqlite` as an interface, to deal with the player state.